### PR TITLE
Add en_US.UTF-8 locale to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM ghcr.io/educelab/ci-docker:dynamic.12.0
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 
-RUN apt-get update && apt-get upgrade -y 
-RUN apt-get install -y libsdl2-dev libgsl-dev
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y libsdl2-dev libgsl-dev locales
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Install volcart
 COPY ./ /volume-cartographer/


### PR DESCRIPTION
Removes the following warning when running VC in the container:

```
root-volume-cartographer-1  | Detected locale "C" with character encoding "ANSI_X3.4-1968", which is not UTF-8.
root-volume-cartographer-1  | Qt depends on a UTF-8 locale, and has switched to "C.UTF-8" instead.
root-volume-cartographer-1  | If this causes problems, reconfigure your locale. See the locale(1) manual
root-volume-cartographer-1  | for more information.
```