### PR TITLE
Fix IOException crashes.

### DIFF
--- a/apps/VC/CWindow.cpp
+++ b/apps/VC/CWindow.cpp
@@ -1626,7 +1626,14 @@ void CWindow::OpenSlice(void)
         prefetchSliceIndex = -1;
         cv.notify_one();
 
-        aImgMat = currentVolume->getSliceData(fPathOnSliceIndex);
+        try {
+            aImgMat = currentVolume->getSliceData(fPathOnSliceIndex);
+        } catch (volcart::IOException e) {
+            std::string statusMessage =
+                "ERROR: Requested slice (" + std::to_string(fPathOnSliceIndex) +
+                ") could not open because: " + std::string(e.what()) + ".";
+            statusBar->showMessage(tr(statusMessage.c_str()), 5000);
+        }
     } else {
         aImgMat = cv::Mat::zeros(10, 10, CV_8UC1);
     }

--- a/apps/VC/CWindow.hpp
+++ b/apps/VC/CWindow.hpp
@@ -148,6 +148,7 @@ private:
     void SetUpAnnotations(void);
 
     void prefetchSlices(void);
+    void prefetchSlice(volcart::Volume::Pointer volume, int index);
     void startPrefetching(int index);
     void OpenSlice(void);
 

--- a/core/include/vc/core/types/Volume.hpp
+++ b/core/include/vc/core/types/Volume.hpp
@@ -213,6 +213,10 @@ public:
     void cachePurge() const;
     /**@}*/
 
+    /** @brief Returns whether slice data has been loaded to cache or can be loaded from disk. */
+    bool hasSliceData(int index) const;
+    /**@}*/
+
 protected:
     /** Slice width */
     int width_{0};

--- a/core/src/Volume.cpp
+++ b/core/src/Volume.cpp
@@ -278,3 +278,16 @@ void Volume::cachePurge() const
     cache_->purge();
 }
 
+bool Volume::hasSliceData(int index) const
+{
+    std::unique_lock<std::shared_mutex> lock(cache_mutex_);
+    if (cache_->contains(index)) {
+        return true;
+    }
+    auto slicePath = getSlicePath(index);
+    if (!fs::exists(slicePath.string())) {
+        return false;
+    }
+    return false;
+}
+


### PR DESCRIPTION
Fix `IOException` crash when opening a new slice. The exception is now handled and an error message is displayed in the status bar for 5 seconds.

This can occur when the scroll volume has incomplete data such as a missing file.

unrelated: The "FILE MISSING" text is poorly aliased, so that could be improved in the future.

## Example
See the status bar message at the bottom.
![image](https://github.com/user-attachments/assets/d7f9a012-9978-4545-b0b3-31717d4d5dfe)
